### PR TITLE
Locked Migrate Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ That's where this package comes in, it provides the following helpers to make yo
 - `./manage.py probe`: a CLI version of the probes with `--live`, `--health`, and `--ready` checks that can be used by Kubernetes probe `exec` commands.
 - `./manage.py wait4db`: sleeps until the database is ready and available
 - `./manage.py ensureadmin`: reads environment variables for an admin user and creates that super user if the record does not already exist in the database.
+- `./manage.py lockedmigrate`: uses a postgres advisory lock to ensure migration safety across multiple processes; useful for a multi-replica deployment with a migrate init container.
 
 More documentation coming soon!
-

--- a/djk8s/management/commands/lockedmigrate.py
+++ b/djk8s/management/commands/lockedmigrate.py
@@ -1,0 +1,39 @@
+from djk8s.conf import settings
+from django.db import connections
+from django.core.management.commands.migrate import Command as MigrateCommand
+
+
+class Command(MigrateCommand):
+
+    help = (
+        "Run Django migrations against postgres with an "
+        "advisory lock; safe across multiple processes."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-L",
+            "--lock-id",
+            type=int,
+            default=settings.DJK8S_MIGRATE_LOCK_ID,
+            help=(
+                "The advisory lock ID to use for migrations."
+            ),
+        )
+        return super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        database = options["database"]
+        if not options["skip_checks"]:
+            self.check(databases=[database])
+
+        conn = connections[database]
+        conn.prepare_database()
+
+        lock_id = options["lock_id"]
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_lock(%s);", [lock_id])
+            try:
+                super().handle(*args, **options)
+            finally:
+                cursor.execute("SELECT pg_advisory_unlock(%s);", [lock_id])


### PR DESCRIPTION
### Scope of changes

Adds a migrate command that uses a postgres advisory lock to prevent concurrent migrates across processes. Useful for init containers on deployments that have more than one replica.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [x] I have added or updated the documentation